### PR TITLE
Fix compilation error for latest rust nightly

### DIFF
--- a/src/rusti/repl.rs
+++ b/src/rusti/repl.rs
@@ -433,7 +433,7 @@ struct ExprType<'a, 'tcx: 'a> {
 impl<'v, 'a, 'tcx> visit::Visitor<'v> for ExprType<'a, 'tcx> {
     fn visit_fn(&mut self, fk: visit::FnKind<'v>, _fd: &'v ast::FnDecl,
             b: &'v ast::Block, _s: codemap::Span, _n: ast::NodeId) {
-        if let visit::FkItemFn(ident, _, _, _, _) = fk {
+        if let visit::FkItemFn(ident, _, _, _, _, _) = fk {
             if &*token::get_ident(ident) == self.fn_name {
                 if let Some(ref stmt) = b.stmts.last() {
                     if let StmtSemi(ref expr, _) = stmt.node {


### PR DESCRIPTION
I was trying to compile with the latest rust nightly and there seems to be a new property on a structure.

Here is the error message it was throwing:

```
$ cargo build
   Compiling rusti v0.0.1 (file:///Users/bruno/rusti)
src/rusti/repl.rs:436:16: 436:50 error: this pattern has 5 fields, but the corresponding variant has 6 fields [E0023]
src/rusti/repl.rs:436         if let visit::FkItemFn(ident, _, _, _, _) = fk {
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: in expansion of if let expansion
src/rusti/repl.rs:436:9: 447:10 note: expansion site
src/rusti/repl.rs:436:16: 436:50 help: run `rustc --explain E0023` to see a detailed explanation
error: aborting due to previous error
Could not compile `rusti`.

To learn more, run the command again with --verbose.
```

As it was a new field, I assumed that it could safely be ignored.

Here is the version info for cargo and rustc

```
cargo --version
cargo 0.2.0-nightly (ac61996 2015-05-17) (built 2015-05-17)
rustc --version
rustc 1.2.0-nightly (7cb9914fc 2015-05-25) (built 2015-05-25)
```
