### PR TITLE
Use CARGO_PKG_VERSION and add note about RUST_SRC_PATH to readme

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,5 +1,5 @@
 Contributors to the Rusti Project include:
 
 Abhishek Chanda <abhishek.becs@gmail.com>
-jonas-schievink <jonas@schievink.net>
+Jonas Schievink <jonas@schievink.net>
 Murarth <murarth@gmail.com>

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ just like interactive mode.
 
 `rusti` provides optional support for code completion using [Racer](https://github.com/phildawes/racer).
 
-To enable code completion, build Racer and install into your `PATH`. You also need to set `RUST_SRC_PATH` to the `src` directory of your local rust checkout so that racer can find the source files.
+To enable code completion, install Racer as outlined in the [Installation Instructions](https://github.com/phildawes/racer#installation) and place the `racer` executable into your `PATH`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ just like interactive mode.
 
 ### Code completion
 
-`rusti` provides optional support for code completion using
-[Racer](https://github.com/phildawes/racer). 
+`rusti` provides optional support for code completion using [Racer](https://github.com/phildawes/racer).
 
-To enable code completion, build Racer and install into your `PATH`.
+To enable code completion, build Racer and install into your `PATH`. You also need to set `RUST_SRC_PATH` to the `src` directory of your local rust checkout so that racer can find the source files.
 
 ## Commands
 

--- a/src/rusti/lib.rs
+++ b/src/rusti/lib.rs
@@ -109,13 +109,8 @@ pub fn run() {
 }
 
 /// Returns a version string.
-pub fn version() -> String {
-    // Is this really the best way to do this?
-    format!("{}.{}.{}{}",
-        env!("CARGO_PKG_VERSION_MAJOR"),
-        env!("CARGO_PKG_VERSION_MINOR"),
-        env!("CARGO_PKG_VERSION_PATCH"),
-        option_env!("CARGO_PKG_VERSION_PRE").unwrap_or(""))
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
 }
 
 fn print_usage(arg0: &str, opts: &Options) {


### PR DESCRIPTION
Completion will silently fail if `RUST_SRC_PATH` isn't set correctly, so I added a note to the readme. Rusti's complete version string is exported by Cargo in the `CARGO_PKG_VERSION` variable, so there's no need to concatenate the different version components.