### PR TITLE
Fix warning that occurs on every REPL command

### DIFF
--- a/src/rusti/repl.rs
+++ b/src/rusti/repl.rs
@@ -271,7 +271,7 @@ impl Repl {
 
         format!(
 r#"#![allow(dead_code, unused_imports, unused_features)]
-#![feature(catch_panic)]
+#![feature(recover)]
 {attrs}
 {vitems}
 {items}
@@ -339,7 +339,7 @@ r#"#![allow(dead_code, unused_imports, unused_features)]
 r#"
 #[no_mangle]
 pub fn {name}() {{
-    let _ = std::thread::catch_panic(_rusti_inner);
+    let _ = std::panic::recover(_rusti_inner);
 }}
 
 fn _rusti_inner() {{


### PR DESCRIPTION
The actual warning is as follows:
<anon>:9:13: 9:37 warning: use of deprecated item: renamed to std::panic::recover, #[warn(deprecated)] on by default
<anon>:9     let _ = std::thread::catch_panic(_rusti_inner);