### PR TITLE
Fix rusti for latest nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
 rusti_tmp_source*
-
+librusti_tmp_source*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+rusti_tmp_source*
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,27 +1,25 @@
-[root]
-name = "rusti"
-version = "0.0.1"
-dependencies = [
- "assert_matches 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "linefeed 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "assert_matches"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "atty"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bitflags"
@@ -29,23 +27,53 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.3.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.14"
+name = "fuchsia-zircon"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -57,35 +85,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
-version = "0.2.24"
+version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linefeed"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.3.8"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,8 +131,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -111,29 +148,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rand"
-version = "0.3.15"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.80"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc_version"
@@ -144,13 +212,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusti"
+version = "0.0.1"
+dependencies = [
+ "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linefeed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "shell32-sys"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,31 +239,52 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "1.1.3"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "thread-id"
-version = "2.0.0"
+name = "termcolor"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.2.7"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -191,8 +292,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf8-ranges"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -206,7 +315,80 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "664470abf00fae0f31c0eb6e1ca12d82961b2a2541ef898bc9dd51a9254d218b"
+"checksum atty 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6609a866dd1a1b2d0ee1362195bf3e4f6438abb2d80120b83b1e1f4fb6476dd0"
+"checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum env_logger 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "00c45cec4cde3daac5f036c74098b4956151525cdf360cff5ee0092c98823e54"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum linefeed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1301a570e4e7d2d0f324b7a3fa73eac85b05c81b656a0983b16ebc8c504e53b6"
+"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0d95c5fa8b641c10ad0b8887454ebaafa3c92b5cd5350f8fc693adafd178e7b"
+"checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
+"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
+"checksum tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8cddbd26c5686ece823b507f304c8f188daef548b4cb753512d929ce478a093c"
+"checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
+"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,11 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,11 +68,6 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "getopts"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "humantime"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +93,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libloading"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "linefeed"
@@ -217,7 +226,7 @@ version = "0.0.1"
 dependencies = [
  "assert_matches 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linefeed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -352,15 +361,16 @@ dependencies = [
 "checksum atty 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6609a866dd1a1b2d0ee1362195bf3e4f6438abb2d80120b83b1e1f4fb6476dd0"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum cc 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8b9d2900f78631a5876dc5d6c9033ede027253efcd33dd36b1309fc6cab97ee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum env_logger 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "00c45cec4cde3daac5f036c74098b4956151525cdf360cff5ee0092c98823e54"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum linefeed 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1301a570e4e7d2d0f324b7a3fa73eac85b05c81b656a0983b16ebc8c504e53b6"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ doc = false
 test = false
 
 [dependencies]
-env_logger = "0.3"
+env_logger = "0.5"
 getopts = "0.2"
-linefeed = "0.2"
-log = "0.3"
-tempfile = "1.1"
+linefeed = "0.4"
+log = "0.4"
+tempfile = "3.0"
 
 [dev-dependencies]
 assert_matches = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ test = false
 
 [dependencies]
 env_logger = "0.5"
-getopts = "0.2"
 linefeed = "0.4"
 log = "0.4"
 tempfile = "3.0"
+libloading = "0.5"
 
 [dev-dependencies]
 assert_matches = "1.0"

--- a/src/rusti/exec.rs
+++ b/src/rusti/exec.rs
@@ -9,7 +9,6 @@
 //! Rust code parsing and compilation.
 
 use std::any::Any;
-use std::ffi::{CStr, CString};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::Command;
@@ -18,233 +17,66 @@ use std::str::from_utf8;
 use std::sync::{Arc, Mutex};
 use std::thread::Builder;
 
-use rustc;
-use rustc_lint;
-
 use rustc::dep_graph::DepGraph;
 use rustc::hir::map as ast_map;
-use rustc_llvm as llvm;
-use rustc::middle::cstore::LinkagePreference::RequireDynamic;
 use rustc::ty;
-use rustc::session::build_session;
-use rustc::session::config::{self, basic_options, build_configuration,
-    ErrorOutputType, Input, Options, OptLevel};
+use rustc::session::config::{self, basic_options, ErrorOutputType, Options, OptLevel};
 use rustc_driver::driver;
 use rustc_metadata::cstore::CStore;
-use rustc_resolve::MakeGlobMap;
-use rustc_trans::ModuleSource;
 
-use syntax::ast::Crate;
-use syntax::codemap::MultiSpan;
+use syntax::codemap::{FileName, MultiSpan};
 use syntax::errors;
 use syntax::errors::emitter::EmitterWriter;
-use syntax::errors::snippet::FormatMode;
-use syntax::errors::registry::Registry;
 use syntax::feature_gate::UnstableFeatures;
 
 /// Compiles input code into an execution environment.
 pub struct ExecutionEngine {
-    ee: llvm::ExecutionEngineRef,
-    modules: Vec<llvm::ModuleRef>,
     /// Additional search paths for libraries
     lib_paths: Vec<String>,
     sysroot: PathBuf,
 }
 
-/// A value that can be translated into `ExecutionEngine` input
-pub trait IntoInput {
-    fn into_input(self) -> Input;
-}
-
-impl<'a> IntoInput for &'a str {
-    fn into_input(self) -> Input {
-        self.to_owned().into_input()
-    }
-}
-
-impl IntoInput for String {
-    fn into_input(self) -> Input {
-        Input::Str{
-            name: "<input>".to_owned(),
-            input: self,
-        }
-    }
-}
-
-impl IntoInput for PathBuf {
-    fn into_input(self) -> Input {
-        Input::File(self)
-    }
-}
-
-type Deps = Vec<PathBuf>;
-
 impl ExecutionEngine {
     /// Constructs a new `ExecutionEngine` with the given library search paths.
     pub fn new(libs: Vec<String>, sysroot: Option<PathBuf>) -> ExecutionEngine {
-        ExecutionEngine::new_with_input(String::new(), libs, sysroot)
-    }
-
-    /// Constructs a new `ExecutionEngine` with the given starting input
-    /// and library search paths.
-    pub fn new_with_input<T>(input: T, libs: Vec<String>, sysroot: Option<PathBuf>) -> ExecutionEngine
-            where T: IntoInput {
         let sysroot = sysroot.unwrap_or_else(get_sysroot);
 
-        let (llmod, deps) = compile_input(input.into_input(),
-            sysroot.clone(), libs.clone())
-            .expect("ExecutionEngine init input failed to compile");
-
-        let ee = unsafe { llvm::LLVMBuildExecutionEngine(llmod) };
-
-        if ee.is_null() {
-            panic!("Failed to create ExecutionEngine: {}", llvm_error());
-        }
-
         let ee = ExecutionEngine{
-            ee: ee,
-            modules: vec![llmod],
             lib_paths: libs,
             sysroot: sysroot,
         };
 
-        ee.load_deps(&deps);
-
         ee
     }
 
-    /// Compile a module and add it to the execution engine.
-    /// If the module fails to compile, errors will be printed to `stderr`
-    /// and `None` will be returned. Otherwise, the module is returned.
-    pub fn add_module<T>(&mut self, input: T) -> Option<llvm::ModuleRef>
-            where T: IntoInput {
-        debug!("compiling module");
-
-        let (llmod, deps) = match compile_input(input.into_input(),
-                self.sysroot.clone(), self.lib_paths.clone()) {
-            Some(r) => r,
-            None => return None,
-        };
-
-        self.load_deps(&deps);
-
-        self.modules.push(llmod);
-
-        unsafe { llvm::LLVMExecutionEngineAddModule(self.ee, llmod); }
-
-        Some(llmod)
-    }
-
-    /// Remove the given module from the execution engine.
-    /// The module is destroyed after it is removed.
-    ///
-    /// # Panics
-    ///
-    /// If the Module does not exist within this `ExecutionEngine`.
-    pub fn remove_module(&mut self, llmod: llvm::ModuleRef) {
-        match self.modules.iter().position(|p| *p == llmod) {
-            Some(i) => {
-                self.modules.remove(i);
-                let res = unsafe {
-                    llvm::LLVMExecutionEngineRemoveModule(self.ee, llmod)
-                };
-
-                assert_eq!(res, 1);
-
-                unsafe { llvm::LLVMDisposeModule(llmod) };
-            },
-            None => panic!("Module not contained in ExecutionEngine"),
+    pub fn call_function_with_source(&mut self, source: &str, name: &str) -> bool {
+        let mut file = ::std::fs::OpenOptions::new().write(true).create(true).truncate(true).open("rusti_tmp_source.rs").unwrap();
+        writeln!(file, "{}", source).unwrap();
+        write!(file, "fn main() {{ {}(); }}", name).unwrap();
+        let args = &[
+            //"rustc".to_string(),
+            "--sysroot".to_string(),
+            self.sysroot.to_str().unwrap().to_owned(),
+            "--crate-type".to_string(), "bin".to_string(),
+            "rusti_tmp_source.rs".to_string(),
+        ];
+        println!("rustc args: {:?}", args);
+        if !Command::new("rustc").args(args).status().unwrap().success() {
+            return false;
         }
-    }
-
-    /// Compiles the given input only up to the analysis phase, calling the
-    /// given closure with a borrowed reference to the type context and
-    /// the produced analysis.
-    pub fn with_analysis<F, R, T>(&self, input: T, f: F) -> Option<R>
-            where F: Send + 'static, R: Send + 'static, T: IntoInput,
-            F: for<'a, 'gcx, 'tcx> FnOnce(&Crate, &ty::TyCtxt<'a, 'gcx, 'tcx>, ty::CrateAnalysis) -> R {
-        with_analysis(f, input.into_input(),
-            self.sysroot.clone(), self.lib_paths.clone())
-    }
-
-    /// Searches for the named function in the set of loaded modules,
-    /// beginning with the most recently added module.
-    /// If the function is found, a raw pointer is returned.
-    /// If the function is not found, `None` is returned.
-    pub fn get_function(&mut self, name: &str) -> Option<*const ()> {
-        let s = CString::new(name.as_bytes()).unwrap();
-
-        for m in self.modules.iter().rev() {
-            let fv = unsafe { llvm::LLVMGetNamedFunction(*m, s.as_ptr()) };
-
-            if !fv.is_null() {
-                let fp = unsafe { llvm::LLVMGetPointerToGlobal(self.ee, fv) };
-
-                assert!(!fp.is_null());
-
-                return Some(fp as *const ());
-            }
-        }
-
-        None
-    }
-
-    /// Searches for the named global in the set of loaded modules,
-    /// beginning with the most recently added module.
-    /// If the global is found, a raw pointer is returned.
-    /// If the global is not found, `None` is returned.
-    pub fn get_global(&mut self, name: &str) -> Option<*const ()> {
-        let s = CString::new(name.as_bytes()).unwrap();
-
-        for m in self.modules.iter().rev() {
-            let gv = unsafe { llvm::LLVMGetNamedGlobal(*m, s.as_ptr()) };
-
-            if !gv.is_null() {
-                let gp = unsafe { llvm::LLVMGetPointerToGlobal(self.ee, gv) };
-
-                assert!(!gp.is_null());
-
-                return Some(gp as *const ());
-            }
-        }
-
-        None
-    }
-
-    /// Loads all dependencies of compiled code.
-    /// Expects a series of paths to dynamic library files.
-    fn load_deps(&self, deps: &Deps) {
-        for path in deps.iter() {
-            debug!("loading crate {}", path.display());
-
-            let s = match path.as_os_str().to_str() {
-                Some(s) => s,
-                None => panic!(
-                    "Could not convert crate path to UTF-8 string: {:?}", path)
-            };
-            let cs = CString::new(s).unwrap();
-
-            let res = unsafe { llvm::LLVMRustLoadDynamicLibrary(cs.as_ptr()) };
-
-            if res == 0 {
-                panic!("Failed to load crate {:?}: {}",
-                    path.display(), llvm_error());
-            }
-        }
+        Command::new("./rusti_tmp_source").status().unwrap();
+        true
     }
 }
 
-impl Drop for ExecutionEngine {
-    fn drop(&mut self) {
-        unsafe { llvm::LLVMDisposeExecutionEngine(self.ee) };
-    }
-}
+struct SyncBuf(Arc<Mutex<Vec<u8>>>);
 
-/// Returns last error from LLVM wrapper code.
-fn llvm_error() -> String {
-    String::from_utf8_lossy(
-        unsafe { CStr::from_ptr(llvm::LLVMRustGetLastError()).to_bytes() })
-        .into_owned()
+impl Write for SyncBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
 /// Runs `rustc` to ask for its sysroot path.
@@ -289,132 +121,6 @@ fn build_exec_options(sysroot: PathBuf, libs: Vec<String>) -> Options {
     opts
 }
 
-struct SyncBuf(Arc<Mutex<Vec<u8>>>);
-
-impl Write for SyncBuf {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
-}
-
-/// Compiles input up to phase 4, translation to LLVM.
-///
-/// Returns the LLVM `ModuleRef` and a series of paths to dynamic libraries
-/// for crates used in the given input.
-fn compile_input(input: Input, sysroot: PathBuf, libs: Vec<String>)
-        -> Option<(llvm::ModuleRef, Deps)> {
-    let r = monitor(move || {
-        let opts = build_exec_options(sysroot, libs);
-        let dep_graph = DepGraph::new(opts.build_dep_graph());
-        let cstore = Rc::new(CStore::new(&dep_graph));
-        let sess = build_session(opts, &dep_graph, None,
-            Registry::new(&rustc::DIAGNOSTICS), cstore.clone());
-        rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
-
-        let cfg = build_configuration(&sess);
-
-        let id = "repl";
-
-        let krate = match driver::phase_1_parse_input(&sess, cfg, &input) {
-            Ok(krate) => krate,
-            Err(mut e) => {
-                e.emit();
-                return None;
-            }
-        };
-
-        check_compile(|| {
-            let driver::ExpansionResult{defs, analysis, resolutions, mut hir_forest, ..} =
-                try!(driver::phase_2_configure_and_expand(
-                    &sess, &cstore, krate, id, None, MakeGlobMap::No, |_| Ok(())));
-
-            let arenas = ty::CtxtArenas::new();
-            let ast_map = ast_map::map_crate(&mut hir_forest, defs);
-
-            driver::phase_3_run_analysis_passes(
-                &sess, ast_map, analysis, resolutions, &arenas, id,
-                |tcx, mir_map, analysis, _| {
-                    tcx.sess.abort_if_errors();
-
-                    let trans = driver::phase_4_translate_to_llvm(
-                        tcx, mir_map.expect("mir_map is None"), analysis);
-
-                    tcx.sess.abort_if_errors();
-
-                    let crates = tcx.sess.cstore.used_crates(RequireDynamic);
-
-                    // Collect crates used in the session.
-                    // Reverse order finds dependencies first.
-                    let deps = crates.into_iter().rev()
-                        .filter_map(|(_, p)| p).collect();
-
-                    assert_eq!(trans.modules.len(), 1);
-                    let llmod = match trans.modules[0].source {
-                        ModuleSource::Translated(ref ll) => ll.llmod,
-                        _ => panic!("translation contains no LLVM module")
-                    };
-
-                    // Workaround because raw pointers do not impl Send
-                    let modp = llmod as usize;
-
-                    (modp, deps)
-                })
-        })
-    });
-
-    r.and_then(|r| r).map(|(modp, deps)| (modp as llvm::ModuleRef, deps))
-}
-
-/// Compiles input up to phase 3, type/region check analysis, and calls
-/// the given closure with the borrowed type context and resulting `CrateAnalysis`.
-fn with_analysis<F, R>(f: F, input: Input, sysroot: PathBuf, libs: Vec<String>) -> Option<R>
-        where F: Send + 'static, R: Send + 'static,
-        F: for<'a, 'gcx, 'tcx> FnOnce(&Crate, &ty::TyCtxt<'a, 'gcx, 'tcx>, ty::CrateAnalysis) -> R {
-    monitor(move || {
-        let opts = build_exec_options(sysroot, libs);
-        let dep_graph = DepGraph::new(opts.build_dep_graph());
-        let cstore = Rc::new(CStore::new(&dep_graph));
-        let sess = build_session(opts, &dep_graph, None,
-            Registry::new(&rustc::DIAGNOSTICS), cstore.clone());
-        rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
-
-        let cfg = build_configuration(&sess);
-
-        let id = "repl";
-
-        let krate = match driver::phase_1_parse_input(&sess, cfg, &input) {
-            Ok(krate) => krate,
-            Err(mut e) => {
-                e.emit();
-                return None;
-            }
-        };
-
-        check_compile(|| {
-            let driver::ExpansionResult{defs, analysis, resolutions, mut hir_forest,
-                    expanded_crate: krate} =
-                try!(driver::phase_2_configure_and_expand(
-                    &sess, &cstore, krate, id, None, MakeGlobMap::No, |_| Ok(())));
-
-            let arenas = ty::CtxtArenas::new();
-            let ast_map = ast_map::map_crate(&mut hir_forest, defs);
-
-            driver::phase_3_run_analysis_passes(
-                &sess, ast_map, analysis, resolutions, &arenas, id,
-                    |tcx, _mir_map, analysis, _| {
-                        let _ignore = tcx.dep_graph.in_ignore();
-                        f(&krate, &tcx, analysis)
-                    })
-        })
-    }).and_then(|r| r)
-}
-
-fn check_compile<F, R>(f: F) -> Option<R> where F: FnOnce() -> Result<R, usize> {
-    f().ok()
-}
-
 fn monitor<F, R>(f: F) -> Option<R>
         where F: Send + 'static + FnOnce() -> R, R: Send + 'static {
     let thread = Builder::new().name("compile_input".to_owned());
@@ -422,8 +128,8 @@ fn monitor<F, R>(f: F) -> Option<R>
     let sink = SyncBuf(data.clone());
 
     let handle = thread.spawn(move || {
-        if !log_enabled!(::log::LogLevel::Debug) {
-            io::set_panic(Box::new(sink));
+        if !log_enabled!(::log::Level::Debug) {
+            io::set_panic(Some(Box::new(sink)));
         }
         f()
     }).unwrap();
@@ -441,7 +147,7 @@ fn handle_compiler_panic(e: Box<Any + Send + 'static>, data: Arc<Mutex<Vec<u8>>>
     if !e.is::<errors::FatalError>() {
         if !e.is::<errors::ExplicitBug>() {
             let emitter = EmitterWriter::stderr(errors::ColorConfig::Auto,
-                None, None, FormatMode::NewErrorFormat);
+                None, false, false);
 
             let handler = errors::Handler::with_emitter(
                 true, false, Box::new(emitter));

--- a/src/rusti/exec.rs
+++ b/src/rusti/exec.rs
@@ -15,24 +15,14 @@ use std::process::Command;
 use std::rc::Rc;
 use std::str::from_utf8;
 use std::sync::{Arc, Mutex};
-use std::thread::Builder;
 use std::cell::RefCell;
 
 use getopts::Matches;
 
-use rustc::dep_graph::DepGraph;
-use rustc::hir::map as ast_map;
 use rustc::ty;
 use rustc::session::Session;
-use rustc::session::config::{self, basic_options, ErrorOutputType, Options, OptLevel};
 use rustc_driver::Compilation;
 use rustc_driver::driver::CompileController;
-use rustc_metadata::cstore::CStore;
-
-use syntax::codemap::{FileName, MultiSpan};
-use syntax::errors;
-use syntax::errors::emitter::EmitterWriter;
-use syntax::feature_gate::UnstableFeatures;
 
 /// Compiles input code into an execution environment.
 pub struct ExecutionEngine {
@@ -56,21 +46,52 @@ impl ExecutionEngine {
         ee
     }
 
+    pub fn prelude(&self) -> String {
+        use std::fmt::Write;
+
+        let mut prelude = format!("#![allow(dead_code, unused_imports, unused_features)]");
+        if self.counter > 0 {
+            writeln!(prelude, "extern crate rusti_tmp_source_{};", self.counter - 1).unwrap();
+            writeln!(prelude, "pub use rusti_tmp_source_{}::*;", self.counter - 1).unwrap();
+        }
+
+        prelude
+    }
+
+    fn rustc_args(&self, start_with_rustc: bool) -> Vec<String> {
+        let mut args = Vec::new();
+        if start_with_rustc {
+            args.push("rustc".to_string());
+        }
+        args.extend(vec!["--sysroot".to_string(),
+            self.sysroot.to_str().unwrap().to_owned(),
+            "-Cprefer-dynamic".to_string(),
+            "-L".to_string(), ".".to_string(),
+            "--crate-type".to_string(), "dylib".to_string(),
+            "--crate-name".to_string(), format!("rusti_tmp_source_{}", self.counter),
+        ].into_iter());
+
+        for i in (0..self.counter).rev() {
+            args.push("--extern".to_string());
+            args.push(format!("rusti_tmp_source_{i}=./librusti_tmp_source_{i}.dylib", i = i));
+        }
+
+        args
+    }
+
     pub fn call_function_with_source(&mut self, source: &str, name: &str) -> bool {
-        let dylib_file = format!("./rusti_tmp_source_{}.dylib", self.counter);
+        let dylib_file = format!("./librusti_tmp_source_{}.dylib", self.counter);
         let _ = ::std::fs::remove_file(&dylib_file);
         let mut file = ::std::fs::OpenOptions::new().write(true).create(true).truncate(true).open("rusti_tmp_source.rs").unwrap();
+        writeln!(file, "{}", self.prelude()).unwrap();
         writeln!(file, "{}", source).unwrap();
         //write!(file, "fn main() {{ {}(); }}", name).unwrap();
-        let args = &[
-            //"rustc".to_string(),
-            "-L".to_string(), ".".to_string(),
-            "--sysroot".to_string(),
-            self.sysroot.to_str().unwrap().to_owned(),
-            "--crate-type".to_string(), "dylib".to_string(),
-            "rusti_tmp_source.rs".to_string(),
-            "-o".to_string(), dylib_file.clone(),
-        ];
+
+        let mut args = self.rustc_args(false);
+        args.push("rusti_tmp_source.rs".to_string());
+        args.push("-o".to_string());
+        args.push(dylib_file.clone());
+
         debug!("rustc args: {:?} fn_name: {}", args, name);
         if !Command::new("rustc").args(args).status().unwrap().success() {
             return false;
@@ -118,27 +139,18 @@ impl ExecutionEngine {
         }
 
         let mut cb = MyCb(f.into(), Rc::new(RefCell::new(None)));
-        let loader = MyFileLoader(prog);
-        ::rustc_driver::run_compiler(&[
-            "rustc".to_string(),
+        let loader = MyFileLoader(format!("{}\n{}", self.prelude(), prog));
+
+        let mut args = self.rustc_args(true);
+        args.extend(vec![
             "dummy_name".to_string(),
             "--crate-type".to_string(), "lib".to_string(),
-            "--sysroot".to_string(),
-            self.sysroot.to_str().unwrap().to_owned(),
-        ], &mut cb, Some(Box::new(loader)), None);
+        ].into_iter());
+
+        ::rustc_driver::run_compiler(&args, &mut cb, Some(Box::new(loader)), None);
         let ret = cb.1.borrow_mut().take().unwrap();
         ret
     }
-}
-
-struct SyncBuf(Arc<Mutex<Vec<u8>>>);
-
-impl Write for SyncBuf {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
 }
 
 /// Runs `rustc` to ask for its sysroot path.
@@ -157,69 +169,4 @@ fn get_sysroot() -> PathBuf {
     debug!("using sysroot: {:?}", path);
 
     PathBuf::from(path)
-}
-
-fn build_exec_options(sysroot: PathBuf, libs: Vec<String>) -> Options {
-    let mut opts = basic_options();
-
-    // librustc derives sysroot from the executable name.
-    // Since we are not rustc, we must specify it.
-    opts.maybe_sysroot = Some(sysroot);
-
-    for p in libs.iter() {
-        opts.search_paths.add_path(&p,
-            ErrorOutputType::HumanReadable(errors::ColorConfig::Auto));
-    }
-
-    // Prefer faster build times
-    opts.optimize = OptLevel::No;
-
-    // Don't require a `main` function
-    opts.crate_types = vec![config::CrateTypeDylib];
-
-    // Allow use of unstable features
-    opts.unstable_features = UnstableFeatures::Allow;
-
-    opts
-}
-
-fn monitor<F, R>(f: F) -> Option<R>
-        where F: Send + 'static + FnOnce() -> R, R: Send + 'static {
-    let thread = Builder::new().name("compile_input".to_owned());
-    let data = Arc::new(Mutex::new(Vec::new()));
-    let sink = SyncBuf(data.clone());
-
-    let handle = thread.spawn(move || {
-        if !log_enabled!(::log::Level::Debug) {
-            io::set_panic(Some(Box::new(sink)));
-        }
-        f()
-    }).unwrap();
-
-    match handle.join() {
-        Ok(r) => Some(r),
-        Err(e) => {
-            handle_compiler_panic(e, data);
-            None
-        }
-    }
-}
-
-fn handle_compiler_panic(e: Box<Any + Send + 'static>, data: Arc<Mutex<Vec<u8>>>) {
-    if !e.is::<errors::FatalError>() {
-        if !e.is::<errors::ExplicitBug>() {
-            let emitter = EmitterWriter::stderr(errors::ColorConfig::Auto,
-                None, false, false);
-
-            let handler = errors::Handler::with_emitter(
-                true, false, Box::new(emitter));
-
-            handler.emit(
-                &MultiSpan::new(),
-                "unexpected panic",
-                errors::Level::Bug);
-        }
-
-        print!("{}", from_utf8(&data.lock().unwrap()).unwrap());
-    }
 }

--- a/src/rusti/lib.rs
+++ b/src/rusti/lib.rs
@@ -16,10 +16,8 @@ extern crate linefeed;
 extern crate rustc;
 extern crate rustc_driver;
 extern crate rustc_lint;
-extern crate rustc_llvm;
 extern crate rustc_metadata;
 extern crate rustc_resolve;
-extern crate rustc_trans;
 extern crate syntax;
 extern crate tempfile;
 
@@ -40,7 +38,7 @@ pub mod repl;
 /// Run `rusti` executable using `env::args`.
 /// Returns desired process exit status.
 pub fn run() -> i32 {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let args = std::env::args().collect::<Vec<_>>();
     let mut opts = Options::new();

--- a/src/rusti/lib.rs
+++ b/src/rusti/lib.rs
@@ -20,6 +20,7 @@ extern crate rustc_metadata;
 extern crate rustc_resolve;
 extern crate syntax;
 extern crate tempfile;
+extern crate libloading;
 
 #[macro_use] extern crate log;
 extern crate env_logger;

--- a/src/rusti/repl.rs
+++ b/src/rusti/repl.rs
@@ -10,12 +10,12 @@
 
 use std::env::args;
 use std::fs::File;
-use std::mem::transmute;
 use std::path::{Path, PathBuf};
 
 use rustc::ty;
 
-use syntax::{ast, codemap};
+use syntax::ast;
+use syntax::codemap::{self, FileName};
 use syntax::ast::StmtKind;
 use syntax::visit::{self, FnKind};
 
@@ -325,9 +325,13 @@ r#"#![allow(dead_code, unused_imports, unused_features)]
         if input.last_expr && !input.statements.is_empty() {
             let stmt = input.statements.last_mut().unwrap();
             if display {
-                *stmt = format!(r#"println!("{{}}", {{ {} }});"#, stmt);
+                *stmt = format!(r#"println!("{{}}", {{
+                                    {}
+                                }});"#, stmt);
             } else {
-                *stmt = format!(r#"println!("{{:?}}", {{ {} }});"#, stmt);
+                *stmt = format!(r#"println!("{{:?}}", {{
+                                    {}
+                                }});"#, stmt);
             }
         }
 
@@ -350,17 +354,7 @@ fn _rusti_inner() {{
             )
         );
 
-        if let Some(_) = self.engine.add_module(prog) {
-            let fp = self.engine.get_function(name).unwrap();
-            let f: fn() = unsafe { transmute(fp) };
-
-            f();
-
-            // NOTE: The module cannot be removed after it is run because tasks
-            // may still be running in the module code. This means that rusti's
-            // memory footprint will only grow over time.
-            // Hopefully, this will not be noticeable in normal use.
-
+        if self.engine.call_function_with_source(&prog, name) {
             // Successful compile means we can add the new items to every program
             self.attributes.extend(input.attributes.into_iter());
             self.view_items.extend(input.view_items.into_iter());
@@ -408,7 +402,7 @@ fn _rusti_inner() {{
     fn expr_type(&self, fn_name: &str, prog: String) -> Option<String> {
         let fn_name = fn_name.to_owned();
 
-        self.engine.with_analysis(prog, move |krate, tcx, _analysis| {
+        /*self.engine.with_analysis(prog, move |krate, tcx, _analysis| {
             let mut v = ExprType{
                 fn_name: fn_name,
                 result: None,
@@ -422,7 +416,8 @@ fn _rusti_inner() {{
             } else {
                 panic!("no type found");
             }
-        })
+        })*/
+        unimplemented!();
     }
 
     fn type_command(&mut self, expr: String) {
@@ -444,7 +439,7 @@ fn {name}() {{
     }
 }
 
-struct ExprType<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
+/*struct ExprType<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     fn_name: String,
     result: Option<String>,
     ty_cx: &'a ty::TyCtxt<'a, 'gcx, 'tcx>,
@@ -466,4 +461,4 @@ impl<'a, 'gcx, 'tcx> visit::Visitor for ExprType<'a, 'gcx, 'tcx> {
             }
         }
     }
-}
+}*/


### PR DESCRIPTION
Instead of using LLVM JIT, this just builds a binary and executes it.

# TODO
* [X] Fix .type
* [x] Use items from previously compiled dylib